### PR TITLE
Tag Visual chanhes

### DIFF
--- a/plugins/TidalTags/src/index.js
+++ b/plugins/TidalTags/src/index.js
@@ -7,16 +7,16 @@ confetti();
 
 // Cache class name and text content pairs to reduce lookup time
 const tagData = {
-	MQA: { className: "quality-tag", textContent: "MQA", color: "#ffd432" },
-	HIRES_LOSSLESS: { className: "quality-tag", textContent: "HiRes", color: "#45eeff" },
-	DOLBY_ATMOS: { className: "quality-tag", textContent: "Atmos", color: "#0052a3" },
+	MQA: { className: "quality-tag quality-tag-mqa", textContent: "MQA"},
+	HIRES_LOSSLESS: { className: "quality-tag quality-tag-hr", textContent: "HiRes"},
+	DOLBY_ATMOS: { className: "quality-tag quality-tag-atmos", textContent: "◗◖" },
 };
 
 const HighQuality = "LOSSLESS";
 
 const qualityMap = {
 	HI_RES: { textContent: "MQA" },
-	HI_RES_LOSSLESS: { textContent: "HIRES LOSSLESS", color: tagData.HIRES_LOSSLESS.color },
+	HI_RES_LOSSLESS: { textContent: "HIRES", color: tagData.HIRES_LOSSLESS.color },
 };
 
 const queryAllAndAttribute = (selector) => {

--- a/plugins/TidalTags/src/style.js
+++ b/plugins/TidalTags/src/style.js
@@ -1,18 +1,36 @@
 export default `
 .quality-tag-container {
 	display: inline-flex;
-	height: 20px;
-	font-size: 12px;
-	line-height: 20px;
+	height: 16px;
+	font-size: 8px;
+	line-height: 16px;
 }
 .quality-tag {
 	justify-content: center;
 	align-items: center;
-	padding: 0 8px;
-	border-radius: 6px;
-	background-color: #222222;
+	padding: 0 6px;
+	border-radius: 5px;
 	box-sizing: border-box;
 	transition: background-color 0.2s;
 	margin-left: 5px;
+	letter-spacing: 0.97px;
+	font-weight: 700;
+}
+
+.quality-tag-mqa {
+	background-color: rgba(249, 186, 122, 0.3);
+	color: rgb(249, 186, 122);
+}
+
+.quality-tag-hr {
+	background-color: rgba(255, 212, 50, 0.3);
+	color: rgb(255, 212, 50);
+}
+
+.quality-tag-atmos {
+    color: rgb(255, 255, 255);
+    background: linear-gradient(0.125turn, rgb(220, 57, 251), rgb(36, 80, 249));
+	font-size: 12px;
+    padding: 0 1px;
 }
 `;


### PR DESCRIPTION
- Uses the tidal previously official colors for mqa/master, Max colors for highres, dolby atmos gradient from their logo
- change dolby atmos text to dolby logo
- removes color change from the playing indicator, cause it's kinda buggy for now

![image](https://github.com/Inrixia/neptune-plugins/assets/16735391/dba96f8b-94a5-437e-ac66-320258c6f595)
