### PR TITLE
fixed multiple download buttons appearing

### DIFF
--- a/plugins/SongDownloader/src/index.js
+++ b/plugins/SongDownloader/src/index.js
@@ -37,6 +37,9 @@ const unloadIntercept = intercept(`contextMenu/OPEN_MEDIA_ITEM`, ([mediaItem]) =
 		const mediaInfo = getState().content.mediaItems.get(mediaItem.id.toString())?.item;
 
 		const contextMenu = document.querySelector(`[data-type="list-container__context-menu"]`);
+		if (document.getElementsByClassName("download-button").length >= 1){
+			document.getElementsByClassName("download-button")[0].remove();
+		}
 
 		const downloadButton = document.createElement("button");
 		downloadButton.type = "button";


### PR DESCRIPTION
if you right clicked on a song but did not download it, then right clicked on another song, there would now be 2 download buttons.  I added a check to see if there is already a download button in the context menu.  If there is, it deletes that button before adding the new one.