### PR TITLE
Cleanup Discord RPC plugin code

### DIFF
--- a/plugins/DiscordRPC/src/Settings.ts
+++ b/plugins/DiscordRPC/src/Settings.ts
@@ -9,27 +9,29 @@ export const settings = getSettings({
 	displayArtistImage: true,
 });
 
+export type Settings = typeof settings;
+
 export const Settings = () => html`<${SwitchSetting}
 		checked=${settings.keepRpcOnPause}
 		onClick=${() => {
-			onTimeUpdate(!settings).catch(() => {});
 			settings.keepRpcOnPause = !settings.keepRpcOnPause;
+			onTimeUpdate().catch(() => {});
 		}}
 		title="Keep RPC on pause"
 	/>
 	<${SwitchSetting}
 		checked=${settings.displayPlayButton}
 		onClick=${() => {
-			onTimeUpdate(!settings).catch(() => {});
 			settings.displayPlayButton = !settings.displayPlayButton;
+			onTimeUpdate().catch(() => {});
 		}}
 		title="Display play button"
 	/>
 	<${SwitchSetting}
 		checked=${settings.displayArtistImage}
 		onClick=${() => {
-			onTimeUpdate(!settings).catch(() => {});
 			settings.displayArtistImage = !settings.displayArtistImage;
+			onTimeUpdate().catch(() => {});
 		}}
 		title="Display artist image"
 	/>`;

--- a/plugins/_lib/nativeBridge/native/discordRPC/updateRPC.native.ts
+++ b/plugins/_lib/nativeBridge/native/discordRPC/updateRPC.native.ts
@@ -1,6 +1,7 @@
 import type { SetActivity } from "@xhayper/discord-rpc";
+import type { TrackItem } from "neptune-types/tidal";
+import type { Settings } from "../../../../DiscordRPC/src";
 import { DiscordRPC } from "./DiscordRPC.native";
-import { PlaybackState, TrackItem } from "neptune-types/tidal";
 
 const rpc = new DiscordRPC("1130698654987067493");
 
@@ -16,78 +17,74 @@ const getMediaURLFromID = (id?: string, path = "/1280x1280.jpg") =>
 		: undefined;
 
 export const onRpcCleanup = () => rpc.cleanup();
-export const updateRPC = async (
-	currentlyPlaying: TrackItem,
-	playbackState: PlaybackState,
-	settings: {
-		keepRpcOnPause: boolean;
-		displayPlayButton: boolean;
-		displayArtistImage: boolean;
-	},
-	currentTime?: number
-) => {
+export const updateRPC = async ({
+	track,
+	playing,
+	settings,
+	currentTime,
+}: {
+	track: TrackItem;
+	playing: boolean;
+	settings: Settings;
+	currentTime?: number;
+}) => {
 	const client = await rpc.getClient();
 
 	const activity: SetActivity = { type: 2 }; // Listening type
 
+	if (!settings) {
+		// Settings occasionally will fail to load
+		settings = {
+			displayArtistImage: true,
+			displayPlayButton: true,
+			keepRpcOnPause: true,
+		};
+	}
+
 	if (settings.displayPlayButton)
 		activity.buttons = [
 			{
-				url:
-					currentlyPlaying.url ??
-					`https://tidal.com/browse/track/${currentlyPlaying.id}?u`,
-				label: "Play on Tidal",
+				url: `https://tidal.com/browse/track/${track.id}?u`,
+				label: "Play song",
 			},
 		];
 
 	// Pause indicator
-	if (playbackState === "NOT_PLAYING") {
+	if (!playing) {
 		if (settings.keepRpcOnPause === false)
 			return client.user.clearActivity();
 		activity.smallImageKey = "paused-icon";
 		activity.smallImageText = "Paused";
 	} else {
 		// Playback/Time
-		if (
-			currentlyPlaying.duration !== undefined &&
-			currentTime !== undefined
-		) {
+		if (track.duration !== undefined && currentTime !== undefined) {
 			activity.startTimestamp = Math.floor(Date.now() / 1000);
 			activity.endTimestamp = Math.floor(
-				(Date.now() +
-					(currentlyPlaying.duration - currentTime) * 1000) /
-					1000
+				(Date.now() + (track.duration - currentTime) * 1000) / 1000
 			);
 		}
 
 		// Artist image
-		if (currentlyPlaying.artist && settings.displayArtistImage) {
+		if (track.artist && settings.displayArtistImage) {
 			activity.smallImageKey = getMediaURLFromID(
-				currentlyPlaying.artist.picture,
+				track.artist.picture,
 				"/320x320.jpg"
 			);
-			activity.smallImageText = formatLongString(
-				currentlyPlaying.artist.name
-			);
+			activity.smallImageText = formatLongString(track.artist.name);
 		}
 	}
 
 	// Album
-	if (currentlyPlaying.album !== undefined) {
-		activity.largeImageKey = getMediaURLFromID(
-			currentlyPlaying.album.cover
-		);
-		activity.largeImageText = formatLongString(
-			currentlyPlaying.album.title
-		);
+	if (track.album !== undefined) {
+		activity.largeImageKey = getMediaURLFromID(track.album.cover);
+		activity.largeImageText = formatLongString(track.album.title);
 	}
 
 	// Title/Artist
 	const artist =
-		currentlyPlaying.artists?.map((a) => a.name).join(", ") ??
-		"Unknown Artist";
+		track.artists?.map((a) => a.name).join(", ") ?? "Unknown Artist";
 
-	activity.details = formatLongString(currentlyPlaying.title);
+	activity.details = formatLongString(track.title);
 	activity.state = formatLongString(artist);
 
 	return client.user.setActivity(activity);


### PR DESCRIPTION
* Cleaned up code and removed some leftover things from tech debt.
* Added an additional song loading check (`IDLE` playback state).
* Made play button always use the share track URL, which presents links to multiple streaming services (though still opens in TIDAL if you have it). Updated button text to reflect that. 