### PR TITLE
Fix Discord RPC always showing as playing on initial load

### DIFF
--- a/plugins/DiscordRPC/src/index.ts
+++ b/plugins/DiscordRPC/src/index.ts
@@ -31,7 +31,8 @@ export const onTimeUpdate = async (currentTime?: number) => {
 	const track = await TrackItemCache.ensure(playbackContext?.actualProductId);
 	if (track === undefined) return;
 
-	const loading = playbackState === "IDLE" || currentTime === 0;
+	const loading =
+		previousActivity && (playbackState === "IDLE" || currentTime === 0);
 	const playing = loading
 		? true // If the track is loading, it's about to play, so we shouldn't show the pause icon
 		: playbackState === "PLAYING";


### PR DESCRIPTION
On the intial load of the Discord RPC plugin, `currentTime` is `0`, which is normally used to detect a song loading. Thus, the plugin thinks a song is loading, and shows it as playing, even though it's not.

This fixes that bug by requiring `previousActivity` to be set for a song to be considered loading.