### PR TITLE
Don't show as paused when seeking in track

### DIFF
--- a/plugins/DiscordRPC/src/index.ts
+++ b/plugins/DiscordRPC/src/index.ts
@@ -31,15 +31,8 @@ export const onTimeUpdate = async (currentTime?: number) => {
 	const track = await TrackItemCache.ensure(playbackContext?.actualProductId);
 	if (track === undefined) return;
 
-	const idle =
-		playbackState === "IDLE" || // Loading next track
-		playbackState === "STALLED" || // Seeking in the track
-		currentTime === 0; // Loading current track
-	const loading = previousActivity && idle; // On the initial load, the state will be idle, but it is not loading
-
-	const playing = loading
-		? true // If the track is loading, it's about to play, so we shouldn't show the pause icon
-		: playbackState === "PLAYING";
+	const loading = currentTime === 0 && previousActivity;
+	const playing = playbackState !== "NOT_PLAYING" || loading;
 
 	if (!playing && !settings.keepRpcOnPause) return updateRPC();
 

--- a/plugins/DiscordRPC/src/index.ts
+++ b/plugins/DiscordRPC/src/index.ts
@@ -25,14 +25,18 @@ const getMediaURLFromID = (id?: string, path = "/1280x1280.jpg") =>
 let previousActivity: string | undefined;
 
 export const onTimeUpdate = async (currentTime?: number) => {
-	let { playbackContext, playbackState } = getPlaybackControl();
+	const { playbackContext, playbackState } = getPlaybackControl();
 	if (!playbackState) return;
 
 	const track = await TrackItemCache.ensure(playbackContext?.actualProductId);
 	if (track === undefined) return;
 
-	const loading =
-		previousActivity && (playbackState === "IDLE" || currentTime === 0);
+	const idle =
+		playbackState === "IDLE" || // Loading next track
+		playbackState === "STALLED" || // Seeking in the track
+		currentTime === 0; // Loading current track
+	const loading = previousActivity && idle; // On the initial load, the state will be idle, but it is not loading
+
 	const playing = loading
 		? true // If the track is loading, it's about to play, so we shouldn't show the pause icon
 		: playbackState === "PLAYING";


### PR DESCRIPTION
`playbackState` of `STALLED` occurs when seeking to a different time position in the track, which shouldn't be considered "paused" as it's just loading. Also added a few comments to explain this behavior.