### PR TITLE
Increase volume scroll speed when holding shift

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Kicks the Tidal cdn if the current playback stalls to make it stop so you never 
 
 ## Volume Scroll
 **Install Url: `https://inrixia.github.io/neptune-plugins/VolumeScroll/`**  
-Lets you scroll on the volume icon to change the volume.
+Lets you scroll on the volume icon to change the volume. Hold shift to change faster.
 
 ## Downloader
 **Install Url: `https://inrixia.github.io/neptune-plugins/SongDownloader/`**  

--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ Kicks the Tidal cdn if the current playback stalls to make it stop so you never 
 
 ## Volume Scroll
 **Install Url: `https://inrixia.github.io/neptune-plugins/VolumeScroll/`**  
-Lets you scroll on the volume icon to change the volume. Hold shift to change faster.
+Lets you scroll on the volume icon to change the volume by 2%. Hold shift to change by 10%.
+![image](https://github.com/user-attachments/assets/3a795666-2ed3-4feb-8d42-9374d4f6edd3)
 
 ## Downloader
 **Install Url: `https://inrixia.github.io/neptune-plugins/SongDownloader/`**  

--- a/plugins/VolumeScroll/plugin.json
+++ b/plugins/VolumeScroll/plugin.json
@@ -1,6 +1,6 @@
 {
 	"name": "Volume Scroll",
-	"description": "Scroll on the volume icon to change volume.",
+	"description": "Scroll on the volume button to change it. (Hold shift to change by 10%)",
 	"author": "Nick Oates",
 	"main": "./src/index.js"
 }

--- a/plugins/VolumeScroll/src/index.ts
+++ b/plugins/VolumeScroll/src/index.ts
@@ -3,7 +3,7 @@ import { actions, intercept, store } from "@neptune";
 function onScroll(event: WheelEvent) {
 	if (!event.deltaY) return;
 	const { playbackControls } = store.getState();
-	const increment = event.shiftKey ? 8 : 2;
+	const increment = event.shiftKey ? 10 : 2;
 	const volumeChange = event.deltaY > 0 ? -increment : increment;
 	const newVolume = playbackControls.volume + volumeChange;
 	const clampVolume = Math.min(100, Math.max(0, newVolume));

--- a/plugins/VolumeScroll/src/index.ts
+++ b/plugins/VolumeScroll/src/index.ts
@@ -3,7 +3,8 @@ import { actions, intercept, store } from "@neptune";
 function onScroll(event: WheelEvent) {
 	if (!event.deltaY) return;
 	const { playbackControls } = store.getState();
-	const volumeChange = event.deltaY > 0 ? -2 : 2;
+	const increment = event.shiftKey ? 8 : 2;
+	const volumeChange = event.deltaY > 0 ? -increment : increment;
 	const newVolume = playbackControls.volume + volumeChange;
 	const clampVolume = Math.min(100, Math.max(0, newVolume));
 	actions.playbackControls.setVolume({


### PR DESCRIPTION
If you hold shift while scrolling on the volume icon, it'll change by increments of 10 instead of 2.

Also added an image for the plugin to `README.md`.
![image](https://github.com/user-attachments/assets/3a795666-2ed3-4feb-8d42-9374d4f6edd3)
