### PR TITLE
Fix duplicate Discord activity

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
 			"hasInstallScript": true,
 			"dependencies": {
 				"@inrixia/helpers": "^2.0.11",
-				"@xhayper/discord-rpc": "^1.1.4",
+				"@xhayper/discord-rpc": "^1.2.0",
 				"dasha": "^3.0.3",
 				"flac-stream-tagger": "^1.0.9",
 				"idb": "^8.0.0",
@@ -34,6 +34,59 @@
 			},
 			"engines": {
 				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@discordjs/collection": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.0.tgz",
+			"integrity": "sha512-mLcTACtXUuVgutoznkh6hS3UFqYirDYAg5Dc1m8xn6OvPjetnUlf/xjtqnnc47OwWdaoCQnHmHh9KofhD6uRqw==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/discordjs/discord.js?sponsor"
+			}
+		},
+		"node_modules/@discordjs/rest": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.3.0.tgz",
+			"integrity": "sha512-C1kAJK8aSYRv3ZwMG8cvrrW4GN0g5eMdP8AuN8ODH5DyOCbHgJspze1my3xHOAgwLJdKUbWNVyAeJ9cEdduqIg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@discordjs/collection": "^2.1.0",
+				"@discordjs/util": "^1.1.0",
+				"@sapphire/async-queue": "^1.5.2",
+				"@sapphire/snowflake": "^3.5.3",
+				"@vladfrangu/async_event_emitter": "^2.2.4",
+				"discord-api-types": "0.37.83",
+				"magic-bytes.js": "^1.10.0",
+				"tslib": "^2.6.2",
+				"undici": "6.13.0"
+			},
+			"engines": {
+				"node": ">=16.11.0"
+			},
+			"funding": {
+				"url": "https://github.com/discordjs/discord.js?sponsor"
+			}
+		},
+		"node_modules/@discordjs/rest/node_modules/discord-api-types": {
+			"version": "0.37.83",
+			"resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.83.tgz",
+			"integrity": "sha512-urGGYeWtWNYMKnYlZnOnDHm8fVRffQs3U0SpE8RHeiuLKb/u92APS8HoQnPTFbnXmY1vVnXjXO4dOxcAn3J+DA==",
+			"license": "MIT"
+		},
+		"node_modules/@discordjs/util": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.1.0.tgz",
+			"integrity": "sha512-IndcI5hzlNZ7GS96RV3Xw1R2kaDuXEp7tRIy/KlhidpN/BQ1qh1NZt3377dMLTa44xDUNKT7hnXkA/oUAzD/lg==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=16.11.0"
+			},
+			"funding": {
+				"url": "https://github.com/discordjs/discord.js?sponsor"
 			}
 		},
 		"node_modules/@electron/get": {
@@ -482,6 +535,26 @@
 			"integrity": "sha512-ode9gx62MsN9ho95GCUkl8M/ocmBlF7OWkL0Eq+2fhpAywlDet9LTOEyN072Rkq77nnV+IqHZKVgKZOvoA8xLg==",
 			"license": "ISC"
 		},
+		"node_modules/@sapphire/async-queue": {
+			"version": "1.5.3",
+			"resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.3.tgz",
+			"integrity": "sha512-x7zadcfJGxFka1Q3f8gCts1F0xMwCKbZweM85xECGI0hBTeIZJGGCrHgLggihBoprlQ/hBmDR5LKfIPqnmHM3w==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=v14.0.0",
+				"npm": ">=7.0.0"
+			}
+		},
+		"node_modules/@sapphire/snowflake": {
+			"version": "3.5.3",
+			"resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.3.tgz",
+			"integrity": "sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=v14.0.0",
+				"npm": ">=7.0.0"
+			}
+		},
 		"node_modules/@sindresorhus/is": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
@@ -589,20 +662,29 @@
 				"npm": ">=5"
 			}
 		},
+		"node_modules/@vladfrangu/async_event_emitter": {
+			"version": "2.4.5",
+			"resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.4.5.tgz",
+			"integrity": "sha512-J7T3gUr3Wz0l7Ni1f9upgBZ7+J22/Q1B7dl0X6fG+fTsD+H+31DIosMHj4Um1dWQwqbcQ3oQf+YS2foYkDc9cQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=v14.0.0",
+				"npm": ">=7.0.0"
+			}
+		},
 		"node_modules/@xhayper/discord-rpc": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/@xhayper/discord-rpc/-/discord-rpc-1.1.4.tgz",
-			"integrity": "sha512-yq2ybstOWsfAN6LP5vogUpnxkaiKV1yXQ+8N4Sgo8YbE+3atgxuNiZWnGG6yO+XdxswvbD04AkLhnq7f9r8h3w==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@xhayper/discord-rpc/-/discord-rpc-1.2.0.tgz",
+			"integrity": "sha512-cKjs9TKzN/7JoozijjszQjUEK1qnLHpEvcJQ2OGFBZjymUzIOH7l14KUu7TQtaIEk0Aw9Bx2w7TfQ0O6tp5mCw==",
+			"license": "ISC",
 			"dependencies": {
-				"axios": "^1.7.2",
+				"@discordjs/rest": "^2.3.0",
+				"@vladfrangu/async_event_emitter": "^2.4.4",
+				"discord-api-types": "^0.37.93",
 				"ws": "^8.18.0"
 			},
 			"engines": {
-				"node": ">=14.18.0"
-			},
-			"optionalDependencies": {
-				"bufferutil": "^4.0.8",
-				"utf-8-validate": "^6.0.4"
+				"node": ">=16.11.0"
 			}
 		},
 		"node_modules/ansi-regex": {
@@ -653,21 +735,6 @@
 			"license": "MIT",
 			"dependencies": {
 				"lodash": "^4.17.14"
-			}
-		},
-		"node_modules/asynckit": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
-		},
-		"node_modules/axios": {
-			"version": "1.7.2",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
-			"integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
-			"dependencies": {
-				"follow-redirects": "^1.15.6",
-				"form-data": "^4.0.0",
-				"proxy-from-env": "^1.1.0"
 			}
 		},
 		"node_modules/balanced-match": {
@@ -751,6 +818,7 @@
 			"integrity": "sha512-4T53u4PdgsXqKaIctwF8ifXlRTTmEPJ8iEPWFdGZvcf7sbwYo6FKFEX9eNNAnzFZ7EzJAQ3CJeOtCRA4rDp7Pw==",
 			"hasInstallScript": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"node-gyp-build": "^4.3.0"
 			},
@@ -919,17 +987,6 @@
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/combined-stream": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-			"dependencies": {
-				"delayed-stream": "~1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.8"
-			}
 		},
 		"node_modules/concat-map": {
 			"version": "0.0.1",
@@ -1136,14 +1193,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/delayed-stream": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-			"integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-			"engines": {
-				"node": ">=0.4.0"
-			}
-		},
 		"node_modules/detect-node": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
@@ -1151,6 +1200,12 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true
+		},
+		"node_modules/discord-api-types": {
+			"version": "0.37.93",
+			"resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.93.tgz",
+			"integrity": "sha512-M5jn0x3bcXk8EI2c6F6V6LeOWq10B/cJf+YJSyqNmg7z4bdXK+Z7g9zGJwHS0h9Bfgs0nun2LQISFOzwck7G9A==",
+			"license": "MIT"
 		},
 		"node_modules/dom-walk": {
 			"version": "0.1.2",
@@ -1379,6 +1434,7 @@
 			"version": "1.15.6",
 			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
 			"integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "individual",
@@ -1393,19 +1449,6 @@
 				"debug": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/form-data": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-			"integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-			"dependencies": {
-				"asynckit": "^0.4.0",
-				"combined-stream": "^1.0.8",
-				"mime-types": "^2.1.12"
-			},
-			"engines": {
-				"node": ">= 6"
 			}
 		},
 		"node_modules/fs-extra": {
@@ -1938,6 +1981,12 @@
 				"global": "^4.4.0"
 			}
 		},
+		"node_modules/magic-bytes.js": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.10.0.tgz",
+			"integrity": "sha512-/k20Lg2q8LE5xiaaSkMXk4sfvI+9EGEykFS4b0CHHGWqDYU0bGUFSwchNOMA56D7TCs9GwVTkqe9als1/ns8UQ==",
+			"license": "MIT"
+		},
 		"node_modules/matcher": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
@@ -1972,25 +2021,6 @@
 			},
 			"engines": {
 				"node": ">=4"
-			}
-		},
-		"node_modules/mime-db": {
-			"version": "1.52.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/mime-types": {
-			"version": "2.1.35",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-			"dependencies": {
-				"mime-db": "1.52.0"
-			},
-			"engines": {
-				"node": ">= 0.6"
 			}
 		},
 		"node_modules/mimic-response": {
@@ -2103,6 +2133,7 @@
 			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.1.tgz",
 			"integrity": "sha512-OSs33Z9yWr148JZcbZd5WiAXhh/n9z8TxQcdMhIOlpN9AhWpLfvVFO73+m77bBABQMaY9XSvIa+qk0jlI7Gcaw==",
 			"optional": true,
+			"peer": true,
 			"bin": {
 				"node-gyp-build": "bin.js",
 				"node-gyp-build-optional": "optional.js",
@@ -2293,11 +2324,6 @@
 			"engines": {
 				"node": ">=0.4.0"
 			}
-		},
-		"node_modules/proxy-from-env": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-			"integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
 		},
 		"node_modules/pstree.remy": {
 			"version": "1.1.8",
@@ -2717,7 +2743,6 @@
 			"version": "2.6.3",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
 			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-			"dev": true,
 			"license": "0BSD"
 		},
 		"node_modules/type-fest": {
@@ -2765,6 +2790,15 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/undici": {
+			"version": "6.13.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-6.13.0.tgz",
+			"integrity": "sha512-Q2rtqmZWrbP8nePMq7mOJIN98M0fYvSgV89vwl/BQRT4mDOeY2GXZngfGpcBBhtky3woM7G24wZV3Q304Bv6cw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.0"
+			}
+		},
 		"node_modules/undici-types": {
 			"version": "5.26.5",
 			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
@@ -2811,6 +2845,7 @@
 			"integrity": "sha512-xu9GQDeFp+eZ6LnCywXN/zBancWvOpUMzgjLPSjy4BRHSmTelvn2E0DG0o1sTiw5hkCKBHo8rwSKncfRfv2EEQ==",
 			"hasInstallScript": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"node-gyp-build": "^4.3.0"
 			},

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 	},
 	"dependencies": {
 		"@inrixia/helpers": "^2.0.11",
-		"@xhayper/discord-rpc": "^1.1.4",
+		"@xhayper/discord-rpc": "^1.2.0",
 		"dasha": "^3.0.3",
 		"flac-stream-tagger": "^1.0.9",
 		"idb": "^8.0.0",

--- a/plugins/DiscordRPC/src/index.ts
+++ b/plugins/DiscordRPC/src/index.ts
@@ -102,5 +102,5 @@ const onUnloadTimeUpdate = intercept(
 onTimeUpdate().catch(trace.msg.err.withContext("Failed to update"));
 export const onUnload = () => {
 	onUnloadTimeUpdate();
-	onRpcCleanup();
+	onRpcCleanup().catch(trace.msg.err.withContext("Failed to cleanup RPC"));
 };

--- a/plugins/_lib/nativeBridge/native/discordRPC/DiscordRPC.native.ts
+++ b/plugins/_lib/nativeBridge/native/discordRPC/DiscordRPC.native.ts
@@ -24,8 +24,7 @@ export class DiscordRPC {
 
 		this.connectingPromise = this.connect();
 		try {
-			const client = await this.connectingPromise;
-			return client;
+			return await this.connectingPromise;
 		} finally {
 			this.connectingPromise = null;
 		}

--- a/plugins/_lib/nativeBridge/native/discordRPC/DiscordRPC.native.ts
+++ b/plugins/_lib/nativeBridge/native/discordRPC/DiscordRPC.native.ts
@@ -18,13 +18,11 @@ export class DiscordRPC {
 			return this.rpcClient as ClientWithUser;
 		}
 
-		if (this.connectingPromise) {
-			return this.connectingPromise;
-		}
+		if (this.connectingPromise) return this.connectingPromise;
 
 		this.connectingPromise = this.connect();
 		try {
-			return await this.connectingPromise;
+			return this.connectingPromise;
 		} finally {
 			this.connectingPromise = null;
 		}

--- a/plugins/_lib/nativeBridge/native/discordRPC/DiscordRPC.native.ts
+++ b/plugins/_lib/nativeBridge/native/discordRPC/DiscordRPC.native.ts
@@ -46,13 +46,6 @@ export class DiscordRPC {
 	}
 
 	async cleanup() {
-		try {
-			await this.rpcClient.destroy();
-		} catch (error) {
-			console.warn(
-				"Encountered error while cleaning up DiscordRPC",
-				error
-			);
-		}
+		await this.rpcClient.destroy();
 	}
 }


### PR DESCRIPTION
There's a race condition with `getClient()`, where if it's called a second time before it resolves initially, it connects to Discord twice and duplicates the activity. This PR fixes that by storing the connection promise, and returning it if it already exists. It happened to me often when starting TIDAL, because we make multiple calls to `onTimeUpdate` (for initial plugin load, then playback start). It also ocassionaly happened when reloading the plugin.

I also removed the `clearActivity` call from `cleanup`. Disconnecting from Discord already clears the activity, so it shouldn't technically be necessary. Additionally, Discord ocassionally procesed `clearActivity()` *after* the disconnect, which would result in a lingering activity.

Updated `@xhayper/discord-rpc` for good measure too.