### PR TITLE
DiscordRPC: Use first artist if track has no primary artist

### DIFF
--- a/plugins/DiscordRPC/src/index.ts
+++ b/plugins/DiscordRPC/src/index.ts
@@ -60,12 +60,13 @@ export const onTimeUpdate = async (currentTime?: number) => {
 		}
 
 		// Artist image
-		if (track.artist && settings.displayArtistImage) {
+		const artist = track.artist || track.artists?.[0];
+		if (artist && settings.displayArtistImage) {
 			activity.smallImageKey = getMediaURLFromID(
-				track.artist.picture,
+				artist.picture,
 				"/320x320.jpg"
 			);
-			activity.smallImageText = formatLongString(track.artist.name);
+			activity.smallImageText = formatLongString(artist.name);
 		}
 	}
 

--- a/plugins/DiscordRPC/src/index.ts
+++ b/plugins/DiscordRPC/src/index.ts
@@ -60,7 +60,7 @@ export const onTimeUpdate = async (currentTime?: number) => {
 		}
 
 		// Artist image
-		const artist = track.artist || track.artists?.[0];
+		const artist = track.artist ?? track.artists?.[0];
 		if (artist && settings.displayArtistImage) {
 			activity.smallImageKey = getMediaURLFromID(
 				artist.picture,


### PR DESCRIPTION
Some tracks don't have a primary artist defined, even when there's only one artist. This PR fixes that by falling back to the first artist in the artists array when there's no primary artist. 