### PR TITLE
Cover Theme plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,12 @@ Kicks the Tidal cdn if the current playback stalls to make it stop so you never 
 Lets you scroll on the volume icon to change the volume by 2%. Hold shift to change by 10%.
 ![image](https://github.com/user-attachments/assets/3a795666-2ed3-4feb-8d42-9374d4f6edd3)
 
+## Cover Theme
+**Install Url: `https://inrixia.github.io/neptune-plugins/CoverTheme/`**
+Theme Tidal based on the current playing songs cover art. Also adds CSS variables for the cover art to be used in custom themes.
+
+![image](https://github.com/user-attachments/assets/99d5dfa9-4e48-4cca-a882-23a7a53cc6f2)
+
 ## Downloader
 **Install Url: `https://inrixia.github.io/neptune-plugins/SongDownloader/`**  
 Adds a Download button to **Songs**, **Playlists** & **Albums** context menus.  

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Lets you scroll on the volume icon to change the volume by 2%. Hold shift to cha
 **Install Url: `https://inrixia.github.io/neptune-plugins/CoverTheme/`**
 Theme Tidal based on the current playing songs cover art. Also adds CSS variables for the cover art to be used in custom themes.
 
-![image](https://github.com/user-attachments/assets/99d5dfa9-4e48-4cca-a882-23a7a53cc6f2)
+![image](https://github.com/user-attachments/assets/57fc931a-e664-495a-a69b-f638e0839d10)
 
 ## Downloader
 **Install Url: `https://inrixia.github.io/neptune-plugins/SongDownloader/`**  

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
 				"dasha": "^3.0.3",
 				"flac-stream-tagger": "^1.0.9",
 				"idb": "^8.0.0",
-				"music-metadata": "^10.0.0"
+				"music-metadata": "^10.0.0",
+				"node-vibrant": "^3.1.6"
 			},
 			"devDependencies": {
 				"@types/node": "^20.14.12",
@@ -535,6 +536,216 @@
 			"integrity": "sha512-ode9gx62MsN9ho95GCUkl8M/ocmBlF7OWkL0Eq+2fhpAywlDet9LTOEyN072Rkq77nnV+IqHZKVgKZOvoA8xLg==",
 			"license": "ISC"
 		},
+		"node_modules/@jimp/bmp": {
+			"version": "0.16.13",
+			"resolved": "https://registry.npmjs.org/@jimp/bmp/-/bmp-0.16.13.tgz",
+			"integrity": "sha512-9edAxu7N2FX7vzkdl5Jo1BbACfycUtBQX+XBMcHA2bk62P8R0otgkHg798frgAk/WxQIzwxqOH6wMiCwrlAzdQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.7.2",
+				"@jimp/utils": "^0.16.13",
+				"bmp-js": "^0.1.0"
+			},
+			"peerDependencies": {
+				"@jimp/custom": ">=0.3.5"
+			}
+		},
+		"node_modules/@jimp/core": {
+			"version": "0.16.13",
+			"resolved": "https://registry.npmjs.org/@jimp/core/-/core-0.16.13.tgz",
+			"integrity": "sha512-qXpA1tzTnlkTku9yqtuRtS/wVntvE6f3m3GNxdTdtmc+O+Wcg9Xo2ABPMh7Nc0AHbMKzwvwgB2JnjZmlmJEObg==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.7.2",
+				"@jimp/utils": "^0.16.13",
+				"any-base": "^1.1.0",
+				"buffer": "^5.2.0",
+				"exif-parser": "^0.1.12",
+				"file-type": "^16.5.4",
+				"load-bmfont": "^1.3.1",
+				"mkdirp": "^0.5.1",
+				"phin": "^2.9.1",
+				"pixelmatch": "^4.0.2",
+				"tinycolor2": "^1.4.1"
+			}
+		},
+		"node_modules/@jimp/core/node_modules/file-type": {
+			"version": "16.5.4",
+			"resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
+			"integrity": "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==",
+			"license": "MIT",
+			"dependencies": {
+				"readable-web-to-node-stream": "^3.0.0",
+				"strtok3": "^6.2.4",
+				"token-types": "^4.1.1"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/file-type?sponsor=1"
+			}
+		},
+		"node_modules/@jimp/core/node_modules/peek-readable": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-4.1.0.tgz",
+			"integrity": "sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Borewit"
+			}
+		},
+		"node_modules/@jimp/core/node_modules/strtok3": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.3.0.tgz",
+			"integrity": "sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==",
+			"license": "MIT",
+			"dependencies": {
+				"@tokenizer/token": "^0.3.0",
+				"peek-readable": "^4.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Borewit"
+			}
+		},
+		"node_modules/@jimp/core/node_modules/token-types": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/token-types/-/token-types-4.2.1.tgz",
+			"integrity": "sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@tokenizer/token": "^0.3.0",
+				"ieee754": "^1.2.1"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Borewit"
+			}
+		},
+		"node_modules/@jimp/custom": {
+			"version": "0.16.13",
+			"resolved": "https://registry.npmjs.org/@jimp/custom/-/custom-0.16.13.tgz",
+			"integrity": "sha512-LTATglVUPGkPf15zX1wTMlZ0+AU7cGEGF6ekVF1crA8eHUWsGjrYTB+Ht4E3HTrCok8weQG+K01rJndCp/l4XA==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.7.2",
+				"@jimp/core": "^0.16.13"
+			}
+		},
+		"node_modules/@jimp/gif": {
+			"version": "0.16.13",
+			"resolved": "https://registry.npmjs.org/@jimp/gif/-/gif-0.16.13.tgz",
+			"integrity": "sha512-yFAMZGv3o+YcjXilMWWwS/bv1iSqykFahFMSO169uVMtfQVfa90kt4/kDwrXNR6Q9i6VHpFiGZMlF2UnHClBvg==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.7.2",
+				"@jimp/utils": "^0.16.13",
+				"gifwrap": "^0.9.2",
+				"omggif": "^1.0.9"
+			},
+			"peerDependencies": {
+				"@jimp/custom": ">=0.3.5"
+			}
+		},
+		"node_modules/@jimp/jpeg": {
+			"version": "0.16.13",
+			"resolved": "https://registry.npmjs.org/@jimp/jpeg/-/jpeg-0.16.13.tgz",
+			"integrity": "sha512-BJHlDxzTlCqP2ThqP8J0eDrbBfod7npWCbJAcfkKqdQuFk0zBPaZ6KKaQKyKxmWJ87Z6ohANZoMKEbtvrwz1AA==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.7.2",
+				"@jimp/utils": "^0.16.13",
+				"jpeg-js": "^0.4.2"
+			},
+			"peerDependencies": {
+				"@jimp/custom": ">=0.3.5"
+			}
+		},
+		"node_modules/@jimp/plugin-resize": {
+			"version": "0.16.13",
+			"resolved": "https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-0.16.13.tgz",
+			"integrity": "sha512-qoqtN8LDknm3fJm9nuPygJv30O3vGhSBD2TxrsCnhtOsxKAqVPJtFVdGd/qVuZ8nqQANQmTlfqTiK9mVWQ7MiQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.7.2",
+				"@jimp/utils": "^0.16.13"
+			},
+			"peerDependencies": {
+				"@jimp/custom": ">=0.3.5"
+			}
+		},
+		"node_modules/@jimp/png": {
+			"version": "0.16.13",
+			"resolved": "https://registry.npmjs.org/@jimp/png/-/png-0.16.13.tgz",
+			"integrity": "sha512-8cGqINvbWJf1G0Her9zbq9I80roEX0A+U45xFby3tDWfzn+Zz8XKDF1Nv9VUwVx0N3zpcG1RPs9hfheG4Cq2kg==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.7.2",
+				"@jimp/utils": "^0.16.13",
+				"pngjs": "^3.3.3"
+			},
+			"peerDependencies": {
+				"@jimp/custom": ">=0.3.5"
+			}
+		},
+		"node_modules/@jimp/tiff": {
+			"version": "0.16.13",
+			"resolved": "https://registry.npmjs.org/@jimp/tiff/-/tiff-0.16.13.tgz",
+			"integrity": "sha512-oJY8d9u95SwW00VPHuCNxPap6Q1+E/xM5QThb9Hu+P6EGuu6lIeLaNBMmFZyblwFbwrH+WBOZlvIzDhi4Dm/6Q==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.7.2",
+				"utif": "^2.0.1"
+			},
+			"peerDependencies": {
+				"@jimp/custom": ">=0.3.5"
+			}
+		},
+		"node_modules/@jimp/types": {
+			"version": "0.16.13",
+			"resolved": "https://registry.npmjs.org/@jimp/types/-/types-0.16.13.tgz",
+			"integrity": "sha512-mC0yVNUobFDjoYLg4hoUwzMKgNlxynzwt3cDXzumGvRJ7Kb8qQGOWJQjQFo5OxmGExqzPphkirdbBF88RVLBCg==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.7.2",
+				"@jimp/bmp": "^0.16.13",
+				"@jimp/gif": "^0.16.13",
+				"@jimp/jpeg": "^0.16.13",
+				"@jimp/png": "^0.16.13",
+				"@jimp/tiff": "^0.16.13",
+				"timm": "^1.6.1"
+			},
+			"peerDependencies": {
+				"@jimp/custom": ">=0.3.5"
+			}
+		},
+		"node_modules/@jimp/utils": {
+			"version": "0.16.13",
+			"resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-0.16.13.tgz",
+			"integrity": "sha512-VyCpkZzFTHXtKgVO35iKN0sYR10psGpV6SkcSeV4oF7eSYlR8Bl6aQLCzVeFjvESF7mxTmIiI3/XrMobVrtxDA==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.7.2",
+				"regenerator-runtime": "^0.13.3"
+			}
+		},
+		"node_modules/@jimp/utils/node_modules/regenerator-runtime": {
+			"version": "0.13.11",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+			"integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+			"license": "MIT"
+		},
 		"node_modules/@sapphire/async-queue": {
 			"version": "1.5.3",
 			"resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.3.tgz",
@@ -616,6 +827,12 @@
 			"dependencies": {
 				"@types/node": "*"
 			}
+		},
+		"node_modules/@types/lodash": {
+			"version": "4.17.7",
+			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.7.tgz",
+			"integrity": "sha512-8wTvZawATi/lsmNu10/j2hk1KEP0IvjubqPE3cu1Xz7xfXXt5oCq3SNUz4fMIP4XGF9Ky+Ue2tBA3hcS7LSBlA==",
+			"license": "MIT"
 		},
 		"node_modules/@types/node": {
 			"version": "20.14.12",
@@ -713,6 +930,12 @@
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
+		"node_modules/any-base": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/any-base/-/any-base-1.1.0.tgz",
+			"integrity": "sha512-uMgjozySS8adZZYePpaWs8cxB9/kdzmpX6SgJZ+wbz1K5eYk5QMYDVJaZKhxyIHUdnnJkfR7SVgStgH7LkGUyg==",
+			"license": "MIT"
+		},
 		"node_modules/anymatch": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
@@ -744,6 +967,26 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/base64-js": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT"
+		},
 		"node_modules/basic-auth": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
@@ -769,6 +1012,12 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
+		},
+		"node_modules/bmp-js": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/bmp-js/-/bmp-js-0.1.0.tgz",
+			"integrity": "sha512-vHdS19CnY3hwiNdkaqk93DvjVLfbEcI8mys4UjuWrlX1haDmroo8o4xCzh4wD6DGV6HxRCyauwhHRqMTfERtjw==",
+			"license": "MIT"
 		},
 		"node_modules/boolean": {
 			"version": "3.2.0",
@@ -802,6 +1051,30 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/buffer": {
+			"version": "5.7.1",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+			"integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"base64-js": "^1.3.1",
+				"ieee754": "^1.1.13"
+			}
+		},
 		"node_modules/buffer-crc32": {
 			"version": "0.2.13",
 			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
@@ -810,6 +1083,15 @@
 			"license": "MIT",
 			"engines": {
 				"node": "*"
+			}
+		},
+		"node_modules/buffer-equal": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz",
+			"integrity": "sha512-RgSV6InVQ9ODPdLWJ5UAqBqJBOg370Nz6ZQtRzpt6nUjc8v0St97uJ4PYC6NztqIScrAXafKM3mZPMygSe1ggA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.4.0"
 			}
 		},
 		"node_modules/bufferutil": {
@@ -859,7 +1141,6 @@
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
 			"integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"es-define-property": "^1.0.0",
@@ -873,6 +1154,15 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/centra": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/centra/-/centra-2.7.0.tgz",
+			"integrity": "sha512-PbFMgMSrmgx6uxCdm57RUos9Tc3fclMvhLSATYN39XsDV29B89zZ3KA89jmY0vwSGazyU+uerqwa6t+KaodPcg==",
+			"license": "MIT",
+			"dependencies": {
+				"follow-redirects": "^1.15.6"
 			}
 		},
 		"node_modules/chalk": {
@@ -1160,7 +1450,6 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
 			"integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"es-define-property": "^1.0.0",
@@ -1262,7 +1551,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
 			"integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"get-intrinsic": "^1.2.4"
@@ -1275,7 +1563,6 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
 			"integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
@@ -1360,6 +1647,11 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/exif-parser": {
+			"version": "0.1.12",
+			"resolved": "https://registry.npmjs.org/exif-parser/-/exif-parser-0.1.12.tgz",
+			"integrity": "sha512-c2bQfLNbMzLPmzQuOr8fy0csy84WmwnER81W88DzTp9CYNPJ6yzOj2EZAh9pywYpqHnshVLHQJ8WzldAyfY+Iw=="
+		},
 		"node_modules/extract-zip": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
@@ -1434,7 +1726,6 @@
 			"version": "1.15.6",
 			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
 			"integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
-			"dev": true,
 			"funding": [
 				{
 					"type": "individual",
@@ -1485,7 +1776,6 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
 			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-			"dev": true,
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -1505,7 +1795,6 @@
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
 			"integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"es-errors": "^1.3.0",
@@ -1535,6 +1824,16 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/gifwrap": {
+			"version": "0.9.4",
+			"resolved": "https://registry.npmjs.org/gifwrap/-/gifwrap-0.9.4.tgz",
+			"integrity": "sha512-MDMwbhASQuVeD4JKd1fKgNgCRL3fGqMM4WaqpNhWO0JiMOAjbQdumbs4BbBZEy9/M00EHEjKN3HieVhCUlwjeQ==",
+			"license": "MIT",
+			"dependencies": {
+				"image-q": "^4.0.0",
+				"omggif": "^1.0.10"
 			}
 		},
 		"node_modules/glob-parent": {
@@ -1600,7 +1899,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
 			"integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"get-intrinsic": "^1.1.3"
@@ -1656,7 +1954,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
 			"integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"es-define-property": "^1.0.0"
@@ -1669,7 +1966,6 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
 			"integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
@@ -1682,7 +1978,6 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
 			"integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
@@ -1695,7 +1990,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
 			"integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"function-bind": "^1.1.2"
@@ -1849,6 +2143,21 @@
 			"dev": true,
 			"license": "ISC"
 		},
+		"node_modules/image-q": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/image-q/-/image-q-4.0.0.tgz",
+			"integrity": "sha512-PfJGVgIfKQJuq3s0tTDOKtztksibuUEbJQIYT3by6wctQo+Rdlh7ef4evJ5NCdxY4CfMbvFkocEwbl4BF8RlJw==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "16.9.1"
+			}
+		},
+		"node_modules/image-q/node_modules/@types/node": {
+			"version": "16.9.1",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.1.tgz",
+			"integrity": "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g==",
+			"license": "MIT"
+		},
 		"node_modules/imageinfo": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/imageinfo/-/imageinfo-1.0.4.tgz",
@@ -1862,6 +2171,12 @@
 			"resolved": "https://registry.npmjs.org/immutable/-/immutable-5.0.0-beta.4.tgz",
 			"integrity": "sha512-sl9RE3lqd2LoQSESc8VV0k8qE9y57iT7dinq3Q+8mR2dqReHDZlgUrudzmFfZhDXBLXlNJMVWv3SG1YpQIokig==",
 			"dev": true
+		},
+		"node_modules/inherits": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+			"license": "ISC"
 		},
 		"node_modules/is-binary-path": {
 			"version": "2.1.0",
@@ -1896,6 +2211,12 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/is-function": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.2.tgz",
+			"integrity": "sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ==",
+			"license": "MIT"
+		},
 		"node_modules/is-glob": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -1918,6 +2239,12 @@
 			"engines": {
 				"node": ">=0.12.0"
 			}
+		},
+		"node_modules/jpeg-js": {
+			"version": "0.4.4",
+			"resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.4.tgz",
+			"integrity": "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==",
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/json-buffer": {
 			"version": "3.0.1",
@@ -1954,11 +2281,38 @@
 				"json-buffer": "3.0.1"
 			}
 		},
+		"node_modules/load-bmfont": {
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/load-bmfont/-/load-bmfont-1.4.2.tgz",
+			"integrity": "sha512-qElWkmjW9Oq1F9EI5Gt7aD9zcdHb9spJCW1L/dmPf7KzCCEJxq8nhHz5eCgI9aMf7vrG/wyaCqdsI+Iy9ZTlog==",
+			"license": "MIT",
+			"dependencies": {
+				"buffer-equal": "0.0.1",
+				"mime": "^1.3.4",
+				"parse-bmfont-ascii": "^1.0.3",
+				"parse-bmfont-binary": "^1.0.5",
+				"parse-bmfont-xml": "^1.1.4",
+				"phin": "^3.7.1",
+				"xhr": "^2.0.1",
+				"xtend": "^4.0.0"
+			}
+		},
+		"node_modules/load-bmfont/node_modules/phin": {
+			"version": "3.7.1",
+			"resolved": "https://registry.npmjs.org/phin/-/phin-3.7.1.tgz",
+			"integrity": "sha512-GEazpTWwTZaEQ9RhL7Nyz0WwqilbqgLahDM3D0hxWwmVDI52nXEybHqiN6/elwpkJBhcuj+WbBu+QfT0uhPGfQ==",
+			"license": "MIT",
+			"dependencies": {
+				"centra": "^2.7.0"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
 		"node_modules/lodash": {
 			"version": "4.17.21",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
 			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/lowercase-keys": {
@@ -2014,7 +2368,6 @@
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
 			"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-			"dev": true,
 			"license": "MIT",
 			"bin": {
 				"mime": "cli.js"
@@ -2058,7 +2411,6 @@
 			"version": "1.2.8",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
 			"integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-			"dev": true,
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -2068,7 +2420,6 @@
 			"version": "0.5.6",
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
 			"integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"minimist": "^1.2.6"
@@ -2140,6 +2491,27 @@
 				"node-gyp-build-test": "build-test.js"
 			}
 		},
+		"node_modules/node-vibrant": {
+			"version": "3.1.6",
+			"resolved": "https://registry.npmjs.org/node-vibrant/-/node-vibrant-3.1.6.tgz",
+			"integrity": "sha512-Wlc/hQmBMOu6xon12ZJHS2N3M+I6J8DhrD3Yo6m5175v8sFkVIN+UjhKVRcO+fqvre89ASTpmiFEP3nPO13SwA==",
+			"license": "MIT",
+			"dependencies": {
+				"@jimp/custom": "^0.16.1",
+				"@jimp/plugin-resize": "^0.16.1",
+				"@jimp/types": "^0.16.1",
+				"@types/lodash": "^4.14.53",
+				"@types/node": "^10.11.7",
+				"lodash": "^4.17.20",
+				"url": "^0.11.0"
+			}
+		},
+		"node_modules/node-vibrant/node_modules/@types/node": {
+			"version": "10.17.60",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
+			"integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
+			"license": "MIT"
+		},
 		"node_modules/nodemon": {
 			"version": "3.1.4",
 			"resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.4.tgz",
@@ -2196,7 +2568,6 @@
 			"version": "1.13.1",
 			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
 			"integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
-			"dev": true,
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -2218,6 +2589,12 @@
 			"resolved": "https://registry.npmjs.org/oby/-/oby-14.3.5.tgz",
 			"integrity": "sha512-0RgL6n1qmxdkUgvXFnmG/J+Lv8HWjwnWmULtu/omMxRUV9KhD/8x3sL7DmanUvEOi5wX4xTbef1sKe5NzqGm7g==",
 			"dev": true
+		},
+		"node_modules/omggif": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/omggif/-/omggif-1.0.10.tgz",
+			"integrity": "sha512-LMJTtvgc/nugXj0Vcrrs68Mn2D1r0zf630VNtqtpI1FEO7e+O9FP4gqs9AcnBaSEeoHIPm28u6qgPR0oyEpGSw==",
+			"license": "MIT"
 		},
 		"node_modules/once": {
 			"version": "1.4.0",
@@ -2249,6 +2626,40 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/pako": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+			"integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+			"license": "(MIT AND Zlib)"
+		},
+		"node_modules/parse-bmfont-ascii": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/parse-bmfont-ascii/-/parse-bmfont-ascii-1.0.6.tgz",
+			"integrity": "sha512-U4RrVsUFCleIOBsIGYOMKjn9PavsGOXxbvYGtMOEfnId0SVNsgehXh1DxUdVPLoxd5mvcEtvmKs2Mmf0Mpa1ZA==",
+			"license": "MIT"
+		},
+		"node_modules/parse-bmfont-binary": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/parse-bmfont-binary/-/parse-bmfont-binary-1.0.6.tgz",
+			"integrity": "sha512-GxmsRea0wdGdYthjuUeWTMWPqm2+FAd4GI8vCvhgJsFnoGhTrLhXDDupwTo7rXVAgaLIGoVHDZS9p/5XbSqeWA==",
+			"license": "MIT"
+		},
+		"node_modules/parse-bmfont-xml": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/parse-bmfont-xml/-/parse-bmfont-xml-1.1.6.tgz",
+			"integrity": "sha512-0cEliVMZEhrFDwMh4SxIyVJpqYoOWDJ9P895tFuS+XuNzI5UBmBk5U5O4KuJdTnZpSBI4LFA2+ZiJaiwfSwlMA==",
+			"license": "MIT",
+			"dependencies": {
+				"xml-parse-from-string": "^1.0.0",
+				"xml2js": "^0.5.0"
+			}
+		},
+		"node_modules/parse-headers": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.5.tgz",
+			"integrity": "sha512-ft3iAoLOB/MlwbNXgzy43SWGP6sQki2jQvAyBg/zDFAgr9bfNWZIUj42Kw2eJIl8kEi4PbgE6U1Zau/HwI75HA==",
+			"license": "MIT"
+		},
 		"node_modules/peek-readable": {
 			"version": "5.1.3",
 			"resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-5.1.3.tgz",
@@ -2269,6 +2680,13 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/phin": {
+			"version": "2.9.3",
+			"resolved": "https://registry.npmjs.org/phin/-/phin-2.9.3.tgz",
+			"integrity": "sha512-CzFr90qM24ju5f88quFC/6qohjC144rehe5n6DH900lgXmUe86+xCKc10ev56gRKC4/BkHUoG4uSiQgBiIXwDA==",
+			"deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+			"license": "MIT"
+		},
 		"node_modules/picomatch": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -2280,6 +2698,27 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/pixelmatch": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-4.0.2.tgz",
+			"integrity": "sha512-J8B6xqiO37sU/gkcMglv6h5Jbd9xNER7aHzpfRdNmV4IbQBzBpe4l9XmbG+xPF/znacgu2jfEw+wHffaq/YkXA==",
+			"license": "ISC",
+			"dependencies": {
+				"pngjs": "^3.0.0"
+			},
+			"bin": {
+				"pixelmatch": "bin/pixelmatch"
+			}
+		},
+		"node_modules/pngjs": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.4.0.tgz",
+			"integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=4.0.0"
 			}
 		},
 		"node_modules/portfinder": {
@@ -2343,11 +2782,16 @@
 				"once": "^1.3.1"
 			}
 		},
+		"node_modules/punycode": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+			"integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
+			"license": "MIT"
+		},
 		"node_modules/qs": {
-			"version": "6.12.1",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.12.1.tgz",
-			"integrity": "sha512-zWmv4RSuB9r2mYQw3zxQuHWeU+42aKi1wWig/j4ele4ygELZ7PEO6MM7rim9oAQH2A5MWfsAVf/jPvTPgCbvUQ==",
-			"dev": true,
+			"version": "6.13.0",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+			"integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"side-channel": "^1.0.6"
@@ -2370,6 +2814,36 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/readable-stream": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+			"license": "MIT",
+			"dependencies": {
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/readable-web-to-node-stream": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.2.tgz",
+			"integrity": "sha512-ePeK6cc1EcKLEhJFt/AebMCLL+GgSKhuygrZ/GLaKZYEecIgIECf4UaUuaByiGtzckwR4ain9VzUh95T1exYGw==",
+			"license": "MIT",
+			"dependencies": {
+				"readable-stream": "^3.6.0"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Borewit"
 			}
 		},
 		"node_modules/readdirp": {
@@ -2479,6 +2953,12 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/sax": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
+			"integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
+			"license": "ISC"
+		},
 		"node_modules/secure-compare": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/secure-compare/-/secure-compare-3.0.1.tgz",
@@ -2542,7 +3022,6 @@
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
 			"integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"define-data-property": "^1.1.4",
@@ -2570,7 +3049,6 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
 			"integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"call-bind": "^1.0.7",
@@ -2617,6 +3095,35 @@
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"optional": true
+		},
+		"node_modules/string_decoder": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+			"license": "MIT",
+			"dependencies": {
+				"safe-buffer": "~5.2.0"
+			}
+		},
+		"node_modules/string_decoder/node_modules/safe-buffer": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT"
 		},
 		"node_modules/string-width": {
 			"version": "4.2.3",
@@ -2688,6 +3195,18 @@
 			"engines": {
 				"node": ">=4"
 			}
+		},
+		"node_modules/timm": {
+			"version": "1.7.1",
+			"resolved": "https://registry.npmjs.org/timm/-/timm-1.7.1.tgz",
+			"integrity": "sha512-IjZc9KIotudix8bMaBW6QvMuq64BrJWFs1+4V0lXwWGQZwH+LnX87doAYhem4caOEusRP9/g6jVDQmZ8XOk1nw==",
+			"license": "MIT"
+		},
+		"node_modules/tinycolor2": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
+			"integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==",
+			"license": "MIT"
 		},
 		"node_modules/to-regex-range": {
 			"version": "5.0.1",
@@ -2827,6 +3346,19 @@
 				"node": ">= 4.0.0"
 			}
 		},
+		"node_modules/url": {
+			"version": "0.11.4",
+			"resolved": "https://registry.npmjs.org/url/-/url-0.11.4.tgz",
+			"integrity": "sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg==",
+			"license": "MIT",
+			"dependencies": {
+				"punycode": "^1.4.1",
+				"qs": "^6.12.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
 		"node_modules/url-join": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
@@ -2852,6 +3384,21 @@
 			"engines": {
 				"node": ">=6.14.2"
 			}
+		},
+		"node_modules/utif": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/utif/-/utif-2.0.1.tgz",
+			"integrity": "sha512-Z/S1fNKCicQTf375lIP9G8Sa1H/phcysstNrrSdZKj1f9g58J4NMgb5IgiEZN9/nLMPDwF0W7hdOe9Qq2IYoLg==",
+			"license": "MIT",
+			"dependencies": {
+				"pako": "^1.0.5"
+			}
+		},
+		"node_modules/util-deprecate": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+			"license": "MIT"
 		},
 		"node_modules/voby": {
 			"version": "0.54.0",
@@ -2919,6 +3466,55 @@
 				"utf-8-validate": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/xhr": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/xhr/-/xhr-2.6.0.tgz",
+			"integrity": "sha512-/eCGLb5rxjx5e3mF1A7s+pLlR6CGyqWN91fv1JgER5mVWg1MZmlhBvy9kjcsOdRk8RrIujotWyJamfyrp+WIcA==",
+			"license": "MIT",
+			"dependencies": {
+				"global": "~4.4.0",
+				"is-function": "^1.0.1",
+				"parse-headers": "^2.0.0",
+				"xtend": "^4.0.0"
+			}
+		},
+		"node_modules/xml-parse-from-string": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/xml-parse-from-string/-/xml-parse-from-string-1.0.1.tgz",
+			"integrity": "sha512-ErcKwJTF54uRzzNMXq2X5sMIy88zJvfN2DmdoQvy7PAFJ+tPRU6ydWuOKNMyfmOjdyBQTFREi60s0Y0SyI0G0g==",
+			"license": "MIT"
+		},
+		"node_modules/xml2js": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+			"integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
+			"license": "MIT",
+			"dependencies": {
+				"sax": ">=0.6.0",
+				"xmlbuilder": "~11.0.0"
+			},
+			"engines": {
+				"node": ">=4.0.0"
+			}
+		},
+		"node_modules/xmlbuilder": {
+			"version": "11.0.1",
+			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+			"integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=4.0"
+			}
+		},
+		"node_modules/xtend": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+			"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.4"
 			}
 		},
 		"node_modules/y18n": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
 		"dasha": "^3.0.3",
 		"flac-stream-tagger": "^1.0.9",
 		"idb": "^8.0.0",
-		"music-metadata": "^10.0.0"
+		"music-metadata": "^10.0.0",
+		"node-vibrant": "^3.1.6"
 	},
 	"nodemonConfig": {
 		"watch": [

--- a/plugins/CoverTheme/package-lock.json
+++ b/plugins/CoverTheme/package-lock.json
@@ -1,0 +1,17 @@
+{
+	"name": "CoverTheme",
+	"lockfileVersion": 3,
+	"requires": true,
+	"packages": {
+		"": {
+			"dependencies": {
+				"@inrixia/lib": "../_lib"
+			}
+		},
+		"../_lib": {},
+		"node_modules/@inrixia/lib": {
+			"resolved": "../_lib",
+			"link": true
+		}
+	}
+}

--- a/plugins/CoverTheme/package.json
+++ b/plugins/CoverTheme/package.json
@@ -1,0 +1,5 @@
+{
+	"dependencies": {
+		"@inrixia/lib": "../_lib"
+	}
+}

--- a/plugins/CoverTheme/plugin.json
+++ b/plugins/CoverTheme/plugin.json
@@ -1,0 +1,6 @@
+{
+	"name": "Cover Theme",
+	"description": "Adds a color background based on the current track's cover art.",
+	"author": "Nick Oates",
+	"main": "./src/index.js"
+}

--- a/plugins/CoverTheme/src/Settings.ts
+++ b/plugins/CoverTheme/src/Settings.ts
@@ -1,0 +1,17 @@
+import { html } from "@neptune/voby";
+import { getSettings } from "@inrixia/lib/storage";
+import { SwitchSetting } from "@inrixia/lib/components/SwitchSetting";
+import { updateCSS } from ".";
+
+export const settings = getSettings({
+	injectCSS: true,
+});
+
+export const Settings = () => html`<${SwitchSetting}
+	checked=${settings.injectCSS}
+	onClick=${() => {
+		settings.injectCSS = !settings.injectCSS;
+		updateCSS();
+	}}
+	title="Inject default CSS styles"
+/>`;

--- a/plugins/CoverTheme/src/Settings.ts
+++ b/plugins/CoverTheme/src/Settings.ts
@@ -4,14 +4,23 @@ import { SwitchSetting } from "@inrixia/lib/components/SwitchSetting";
 import { updateCSS } from ".";
 
 export const settings = getSettings({
-	injectCSS: true,
+	transparentTheme: true,
+	backgroundGradient: true,
 });
 
-export const Settings = () => html`<${SwitchSetting}
-	checked=${settings.injectCSS}
-	onClick=${() => {
-		settings.injectCSS = !settings.injectCSS;
-		updateCSS();
-	}}
-	title="Inject default CSS styles"
-/>`;
+export const Settings = () => html` <${SwitchSetting}
+		checked=${settings.transparentTheme}
+		onClick=${() => {
+			settings.transparentTheme = !settings.transparentTheme;
+			updateCSS();
+		}}
+		title="Transparent theme"
+	/>
+	<${SwitchSetting}
+		checked=${settings.backgroundGradient}
+		onClick=${() => {
+			settings.backgroundGradient = !settings.backgroundGradient;
+			updateCSS();
+		}}
+		title="Background gradient"
+	/>`;

--- a/plugins/CoverTheme/src/index.ts
+++ b/plugins/CoverTheme/src/index.ts
@@ -51,7 +51,6 @@ async function updateBackground() {
 				`radial-gradient(ellipse at ${position}, ${color}, transparent 70%)`
 		)
 		.join(", ");
-	console.log({ style, colors });
 
 	document.body.style.backgroundImage = style;
 }

--- a/plugins/CoverTheme/src/index.ts
+++ b/plugins/CoverTheme/src/index.ts
@@ -56,4 +56,6 @@ export const onUnload = () => {
 	unloadIntercept();
 	document.body.style.backgroundImage = "";
 	getStyle("coverTheme")?.remove();
+	prevSong = undefined;
+	prevCover = undefined;
 };

--- a/plugins/CoverTheme/src/index.ts
+++ b/plugins/CoverTheme/src/index.ts
@@ -50,45 +50,47 @@ const unloadIntercept = intercept("playbackControls/TIME_UPDATE", ([time]) => {
 	if (time === 0) updateBackground();
 });
 
-const positions = {
-	"top left": "LightMuted",
-	"center left": "Vibrant",
-	"bottom left": "DarkVibrant",
-	"top right": "LightVibrant",
-	"center right": "Muted",
-	"bottom right": "DarkMuted",
-};
-
-const gradients = Object.entries(positions)
-	.map(
-		([position, variable]) =>
-			`radial-gradient(ellipse at ${position}, rgb(var(--cover-${variable}), 0.5), transparent 70%)`
-	)
-	.join(", ");
-
-const styles = `
-#wimp, main, .sidebarWrapper, [class^="mainContainer"] {
-	background: unset !important;
-}
-			
-#footerPlayer, nav, [class^="bar"] {
-	background-color: color-mix(in srgb, var(--wave-color-solid-base-brighter), transparent 70%) !important;
-}
-		
-#nowPlaying > [class^="innerContainer"] {
-	height: calc(100vh - 126px);
-	overflow: hidden;
-}
-	
-body {
-	background-image: ${gradients};
-}`;
-
 export function updateCSS() {
-	if (settings.injectCSS) {
-		setStyle(styles, "coverTheme");
+	if (settings.transparentTheme) {
+		const styles = `
+		#wimp, main, .sidebarWrapper, [class^="mainContainer"] {
+			background: unset !important;
+		}
+					
+		#footerPlayer, nav, [class^="bar"] {
+			background-color: color-mix(in srgb, var(--wave-color-solid-base-brighter), transparent 70%) !important;
+		}
+				
+		#nowPlaying > [class^="innerContainer"] {
+			height: calc(100vh - 126px);
+			overflow: hidden;
+		}`;
+
+		setStyle(styles, "transparentTheme");
 	} else {
-		getStyle("coverTheme")?.remove();
+		getStyle("transparentTheme")?.remove();
+	}
+
+	if (settings.backgroundGradient) {
+		const positions = {
+			"top left": "LightMuted",
+			"center left": "Vibrant",
+			"bottom left": "DarkVibrant",
+			"top right": "LightVibrant",
+			"center right": "Muted",
+			"bottom right": "DarkMuted",
+		};
+
+		const gradients = Object.entries(positions)
+			.map(
+				([position, variable]) =>
+					`radial-gradient(ellipse at ${position}, rgb(var(--cover-${variable}), 0.5), transparent 70%)`
+			)
+			.join(", ");
+
+		setStyle(`body{background-image:${gradients};}`, "backgroundGradient");
+	} else {
+		getStyle("backgroundGradient")?.remove();
 	}
 }
 

--- a/plugins/CoverTheme/src/index.ts
+++ b/plugins/CoverTheme/src/index.ts
@@ -3,11 +3,12 @@ import getPlaybackControl from "@inrixia/lib/getPlaybackControl";
 import { TrackItemCache } from "@inrixia/lib/Caches/TrackItemCache";
 import Vibrant from "node-vibrant";
 import { getStyle, setStyle } from "@inrixia/lib/css/setStyle";
-import { Palette, Vec3 } from "node-vibrant/lib/color";
+import { settings } from "./Settings";
+export { Settings } from "./Settings";
 
-// These variables are used to prevent unnecessary updates
 let prevSong: string | undefined;
 let prevCover: string | undefined;
+let vars: string[] = [];
 
 const getCoverUrl = (id: string) =>
 	"https://resources.tidal.com/images/" +
@@ -29,57 +30,77 @@ async function updateBackground() {
 	const cover = getCoverUrl(track.album.cover);
 	const palette = await Vibrant.from(cover).getPalette();
 
-	const colors: { [K in keyof Palette]: string } = {};
-	Object.entries(palette).forEach(([colorName, color]) => {
-		if (!color) return;
-		const rgb = color.rgb.join(", ");
-		colors[colorName] = `rgb(${rgb}, 0.5)`;
-	});
+	for (const [colorName, color] of Object.entries(palette)) {
+		const variableName = `--cover-${colorName}`;
+		if (!color) {
+			document.documentElement.style.setProperty(variableName, null);
+			continue;
+		}
 
-	const gradients = {
-		"top left": colors.LightMuted,
-		"center left": colors.Vibrant,
-		"bottom left": colors.DarkVibrant,
-		"top right": colors.LightVibrant,
-		"center right": colors.Muted,
-		"bottom right": colors.DarkMuted,
-	};
+		if (!vars.includes(variableName)) vars.push(variableName);
 
-	const style = Object.entries(gradients)
-		.map(
-			([position, color]) =>
-				`radial-gradient(ellipse at ${position}, ${color}, transparent 70%)`
-		)
-		.join(", ");
-
-	document.body.style.backgroundImage = style;
+		document.documentElement.style.setProperty(
+			variableName,
+			color.rgb.join(", ")
+		);
+	}
 }
 
 const unloadIntercept = intercept("playbackControls/TIME_UPDATE", ([time]) => {
 	if (time === 0) updateBackground();
 });
 
-updateBackground();
-setStyle(
-	`#wimp, main, .sidebarWrapper, [class^="mainContainer"] {
-		background: unset !important;
-	}
+const positions = {
+	"top left": "LightMuted",
+	"center left": "Vibrant",
+	"bottom left": "DarkVibrant",
+	"top right": "LightVibrant",
+	"center right": "Muted",
+	"bottom right": "DarkMuted",
+};
+
+const gradients = Object.entries(positions)
+	.map(
+		([position, variable]) =>
+			`radial-gradient(ellipse at ${position}, rgb(var(--cover-${variable}), 0.5), transparent 70%)`
+	)
+	.join(", ");
+
+const styles = `
+#wimp, main, .sidebarWrapper, [class^="mainContainer"] {
+	background: unset !important;
+}
+			
+#footerPlayer, nav, [class^="bar"] {
+	background-color: color-mix(in srgb, var(--wave-color-solid-base-brighter), transparent 70%) !important;
+}
 		
-	#footerPlayer, nav, [class^="bar"] {
-		background-color: color-mix(in srgb, var(--wave-color-solid-base-brighter), transparent 70%) !important;
-	}
+#nowPlaying > [class^="innerContainer"] {
+	height: calc(100vh - 126px);
+	overflow: hidden;
+}
 	
-	#nowPlaying > [class^="innerContainer"] {
-		height: calc(100vh - 126px);
-		overflow: hidden;
-	}`,
-	"coverTheme"
-);
+body {
+	background-image: ${gradients};
+}`;
+
+export function updateCSS() {
+	if (settings.injectCSS) {
+		setStyle(styles, "coverTheme");
+	} else {
+		getStyle("coverTheme")?.remove();
+	}
+}
+
+updateCSS();
+updateBackground();
 
 export const onUnload = () => {
 	unloadIntercept();
-	document.body.style.backgroundImage = "";
 	getStyle("coverTheme")?.remove();
+	vars.forEach((variable) =>
+		document.documentElement.style.removeProperty(variable)
+	);
 	prevSong = undefined;
 	prevCover = undefined;
 };

--- a/plugins/CoverTheme/src/index.ts
+++ b/plugins/CoverTheme/src/index.ts
@@ -73,9 +73,9 @@ export function updateCSS() {
 
 	if (settings.backgroundGradient) {
 		const positions = {
-			"top left": "LightMuted",
+			"top left": "DarkVibrant",
 			"center left": "Vibrant",
-			"bottom left": "DarkVibrant",
+			"bottom left": "LightMuted",
 			"top right": "LightVibrant",
 			"center right": "Muted",
 			"bottom right": "DarkMuted",

--- a/plugins/CoverTheme/src/index.ts
+++ b/plugins/CoverTheme/src/index.ts
@@ -26,13 +26,13 @@ async function updateBackground() {
 	prevCover = track.album.cover;
 
 	const cover = getCoverUrl(track.album.cover);
-	const palette = await Vibrant.from(cover).maxColorCount(128).getPalette();
+	const palette = await Vibrant.from(cover).getPalette();
 
-	const vibrant = palette.Vibrant?.rgb.join(", ");
-	const muted = palette.Muted?.rgb.join(", ");
+	const vibrant = palette.DarkVibrant?.hex;
+	const muted = palette.DarkMuted?.hex;
 	if (!vibrant || !muted) return;
 
-	const style = `linear-gradient(rgb(${vibrant}, 0.5), rgb(${muted}, 0.5))`;
+	const style = `linear-gradient(${vibrant}, ${muted})`;
 	document.body.style.backgroundImage = style;
 }
 

--- a/plugins/CoverTheme/src/index.ts
+++ b/plugins/CoverTheme/src/index.ts
@@ -48,6 +48,11 @@ setStyle(
 		
 	#footerPlayer, nav, [class^="bar"] {
 		background-color: color-mix(in srgb, var(--wave-color-solid-base-brighter), transparent 70%) !important;
+	}
+	
+	#nowPlaying > [class^="innerContainer"] {
+		height: calc(100vh - 126px);
+		overflow: hidden;
 	}`,
 	"coverTheme"
 );

--- a/plugins/CoverTheme/src/index.ts
+++ b/plugins/CoverTheme/src/index.ts
@@ -3,6 +3,7 @@ import getPlaybackControl from "@inrixia/lib/getPlaybackControl";
 import { TrackItemCache } from "@inrixia/lib/Caches/TrackItemCache";
 import Vibrant from "node-vibrant";
 import { getStyle, setStyle } from "@inrixia/lib/css/setStyle";
+import { Palette, Vec3 } from "node-vibrant/lib/color";
 
 // These variables are used to prevent unnecessary updates
 let prevSong: string | undefined;
@@ -28,11 +29,30 @@ async function updateBackground() {
 	const cover = getCoverUrl(track.album.cover);
 	const palette = await Vibrant.from(cover).getPalette();
 
-	const vibrant = palette.DarkVibrant?.hex;
-	const muted = palette.DarkMuted?.hex;
-	if (!vibrant || !muted) return;
+	const colors: { [K in keyof Palette]: string } = {};
+	Object.entries(palette).forEach(([colorName, color]) => {
+		if (!color) return;
+		const rgb = color.rgb.join(", ");
+		colors[colorName] = `rgb(${rgb}, 0.5)`;
+	});
 
-	const style = `linear-gradient(${vibrant}, ${muted})`;
+	const gradients = {
+		"top left": colors.LightMuted,
+		"center left": colors.Vibrant,
+		"bottom left": colors.DarkVibrant,
+		"top right": colors.LightVibrant,
+		"center right": colors.Muted,
+		"bottom right": colors.DarkMuted,
+	};
+
+	const style = Object.entries(gradients)
+		.map(
+			([position, color]) =>
+				`radial-gradient(ellipse at ${position}, ${color}, transparent 70%)`
+		)
+		.join(", ");
+	console.log({ style, colors });
+
 	document.body.style.backgroundImage = style;
 }
 

--- a/plugins/CoverTheme/src/index.ts
+++ b/plugins/CoverTheme/src/index.ts
@@ -1,0 +1,59 @@
+import { intercept } from "@neptune";
+import getPlaybackControl from "@inrixia/lib/getPlaybackControl";
+import { TrackItemCache } from "@inrixia/lib/Caches/TrackItemCache";
+import Vibrant from "node-vibrant";
+import { getStyle, setStyle } from "@inrixia/lib/css/setStyle";
+
+// These variables are used to prevent unnecessary updates
+let prevSong: string | undefined;
+let prevCover: string | undefined;
+
+const getCoverUrl = (id: string) =>
+	"https://resources.tidal.com/images/" +
+	id.split("-").join("/") +
+	"/640x640.jpg?cors";
+
+async function updateBackground() {
+	const { playbackContext } = getPlaybackControl();
+
+	if (prevSong === playbackContext?.actualProductId) return;
+	prevSong = playbackContext?.actualProductId;
+
+	const track = await TrackItemCache.ensure(playbackContext?.actualProductId);
+	if (!track || !track.album?.cover) return;
+
+	if (prevCover === track.album.cover) return;
+	prevCover = track.album.cover;
+
+	const cover = getCoverUrl(track.album.cover);
+	const palette = await Vibrant.from(cover).maxColorCount(128).getPalette();
+
+	const vibrant = palette.Vibrant?.rgb.join(", ");
+	const muted = palette.Muted?.rgb.join(", ");
+	if (!vibrant || !muted) return;
+
+	const style = `linear-gradient(rgb(${vibrant}, 0.5), rgb(${muted}, 0.5))`;
+	document.body.style.backgroundImage = style;
+}
+
+const unloadIntercept = intercept("playbackControls/TIME_UPDATE", ([time]) => {
+	if (time === 0) updateBackground();
+});
+
+updateBackground();
+setStyle(
+	`#wimp, main, .sidebarWrapper, [class^="mainContainer"] {
+		background: unset !important;
+	}
+		
+	#footerPlayer, nav, [class^="bar"] {
+		background-color: color-mix(in srgb, var(--wave-color-solid-base-brighter), transparent 70%) !important;
+	}`,
+	"coverTheme"
+);
+
+export const onUnload = () => {
+	unloadIntercept();
+	document.body.style.backgroundImage = "";
+	getStyle("coverTheme")?.remove();
+};


### PR DESCRIPTION
This plugin themes Tidal based on the current track's cover art. It uses [`node-vibrant`](https://github.com/Vibrant-Colors/node-vibrant/) to create a palette, then adds CSS variables of those colors.

A default theme is included, but it can be disabled if you're using your own theme. It adds a background gradient of the colors, and makes parts of the app transparent so the gradient is visible.

![image](https://github.com/user-attachments/assets/57fc931a-e664-495a-a69b-f638e0839d10)

- [x] Fix now playing view overlapping player. 