### PR TITLE
[SongDownloader] Added path separator based on user agent OS

### DIFF
--- a/plugins/SongDownloader/src/index.ts
+++ b/plugins/SongDownloader/src/index.ts
@@ -1,7 +1,7 @@
 import "@inrixia/lib/contentButton.styles";
 
 import { TrackItem } from "neptune-types/tidal";
-import { parseFileName } from "./parseFileName";
+import { parseFileName, pathSeparator } from "./parseFileName";
 
 import { Tracer } from "@inrixia/lib/trace";
 const trace = Tracer("[SongDownloader]");
@@ -118,11 +118,11 @@ const downloadTrack = async (trackItem: TrackItem, updateMethods: ButtonMethods,
 	if (folderPath === undefined || !settings.alwaysUseDefaultPath) {
 		updateMethods.set("Prompting for download path...");
 		const fileName = pathInfo.fileName;
-		const dialogResult = await saveDialog({ defaultPath: `${folderPath ?? ""}\\${fileName}`, filters: [{ name: "", extensions: [fileName ?? "*"] }] });
+		const dialogResult = await saveDialog({ defaultPath: `${folderPath ?? ""}${pathSeparator}${fileName}`, filters: [{ name: "", extensions: [fileName ?? "*"] }] });
 		if (dialogResult.canceled) return updateMethods.clear();
-		const dialogParts = dialogResult.filePath.split("\\");
+		const dialogParts = dialogResult.filePath.split(pathSeparator);
 		dialogParts.pop();
-		pathInfo.basePath = dialogParts.join("\\");
+		pathInfo.basePath = dialogParts.join(pathSeparator);
 	}
 
 	updateMethods.set("Downloading...");

--- a/plugins/SongDownloader/src/parseFileName.ts
+++ b/plugins/SongDownloader/src/parseFileName.ts
@@ -29,13 +29,15 @@ const filePathFromInfo = ({ tags }: MetaTags, { manifest, manifestMimeType }: Ex
 	}
 };
 
+export const pathSeparator = navigator.userAgent.includes("Win") ? "\\" : "/";
+
 export const parseFileName = (metaTags: MetaTags, extPlaybackInfo: ExtendedPlayackInfo): PathInfo => {
-	const filePath = filePathFromInfo(metaTags, extPlaybackInfo);
-	let pathParts = filePath.replaceAll("/", "\\").split("\\");
+	let filePath = filePathFromInfo(metaTags, extPlaybackInfo);
+	filePath = pathSeparator === "\\" ? filePath.replaceAll("/", pathSeparator) : filePath;
+	let pathParts = filePath.split(pathSeparator);
 	const fileName = pathParts.pop();
-	console.log(fileName, pathParts);
 	return {
 		fileName,
-		folderPath: pathParts.join("\\"),
+		folderPath: pathParts.join(pathSeparator),
 	};
 };

--- a/plugins/_lib/nativeBridge/native/downloadTrack.native.ts
+++ b/plugins/_lib/nativeBridge/native/downloadTrack.native.ts
@@ -46,6 +46,8 @@ export type PathInfo = {
 	basePath?: string;
 };
 
+const pathSeparator = process.platform === "win32" ? "\\" : "/";
+
 const downloadStatus: Record<string, DownloadProgress> = {};
 export const startTrackDownload = async (extPlaybackInfo: ExtendedPlayackInfo, pathInfo: PathInfo, metaTags?: MetaTags): Promise<void> => {
 	const pathKey = JSON.stringify(pathInfo);
@@ -55,7 +57,7 @@ export const startTrackDownload = async (extPlaybackInfo: ExtendedPlayackInfo, p
 		if (folderPath !== ".") await mkdir(folderPath, { recursive: true });
 		const stream = await requestTrackStream(extPlaybackInfo, { onProgress: (progress) => (downloadStatus[pathKey] = progress) });
 		const metaStream = await addTags(extPlaybackInfo, stream, metaTags);
-		const writeStream = createWriteStream(`${folderPath}\\${pathInfo.fileName}`);
+		const writeStream = createWriteStream(`${folderPath}${pathSeparator}${pathInfo.fileName}`);
 		return new Promise((res, rej) =>
 			metaStream
 				.pipe(writeStream)


### PR DESCRIPTION
Plugin: SongDownloader

Currently, the path separators used in the file save dialog, as well as path of the downloaded file, use a backslash instead of a forward slash. The changes take into account the operating system (via Electron's `process.platform` and the "browser's" `navigator.userAgent`) and change the path separator accordingly.

Settings:
<img width="476" alt="Screenshot 2024-09-04 at 21 42 55" src="https://github.com/user-attachments/assets/d7bc5cb1-b6e7-4775-bbdb-aa29df2a30d7">

Before:
<img width="436" alt="Screenshot 2024-09-04 at 21 38 59" src="https://github.com/user-attachments/assets/13b35999-5d65-4103-8568-f292a759ba8a">
<img width="134" alt="Screenshot 2024-09-04 at 21 38 37" src="https://github.com/user-attachments/assets/15c7aadf-cc23-4fc6-a3d2-3a0b1349a0ed">

Afterwards:
<img width="542" alt="Screenshot 2024-09-04 at 21 35 21" src="https://github.com/user-attachments/assets/88247e86-22d5-463c-bd2c-ce7b2bb2d783">
<img width="245" alt="image" src="https://github.com/user-attachments/assets/5a258c0a-f2e7-421f-9afe-c1b12b5a701f">
