### PR TITLE
Discord RPC updates

### DIFF
--- a/plugins/DiscordRPC/src/Settings.ts
+++ b/plugins/DiscordRPC/src/Settings.ts
@@ -1,7 +1,7 @@
 import { html } from "@neptune/voby";
 import { getSettings } from "@inrixia/lib/storage";
 import { SwitchSetting } from "@inrixia/lib/components/SwitchSetting";
-import { onTimeUpdate } from ".";
+import { update } from ".";
 
 export const settings = getSettings({
 	keepRpcOnPause: true,
@@ -13,7 +13,7 @@ export const Settings = () => html`<${SwitchSetting}
 		checked=${settings.keepRpcOnPause}
 		onClick=${() => {
 			settings.keepRpcOnPause = !settings.keepRpcOnPause;
-			onTimeUpdate().catch(() => {});
+			update();
 		}}
 		title="Keep RPC on pause"
 	/>
@@ -21,7 +21,7 @@ export const Settings = () => html`<${SwitchSetting}
 		checked=${settings.displayPlayButton}
 		onClick=${() => {
 			settings.displayPlayButton = !settings.displayPlayButton;
-			onTimeUpdate().catch(() => {});
+			update();
 		}}
 		title="Display play button"
 	/>
@@ -29,7 +29,7 @@ export const Settings = () => html`<${SwitchSetting}
 		checked=${settings.displayArtistImage}
 		onClick=${() => {
 			settings.displayArtistImage = !settings.displayArtistImage;
-			onTimeUpdate().catch(() => {});
+			update();
 		}}
 		title="Display artist image"
 	/>`;

--- a/plugins/DiscordRPC/src/index.ts
+++ b/plugins/DiscordRPC/src/index.ts
@@ -26,9 +26,9 @@ export function update(data?: {
 	time?: number;
 	paused?: boolean;
 }) {
-	if (data?.track) track = data.track;
-	if (data?.paused !== undefined) paused = data.paused;
-	if (data?.time !== undefined) time = data.time;
+	track = data?.track ?? track;
+	paused = data?.paused ?? paused;
+	time = data?.time ?? time;
 
 	// Clear activity if no track or paused
 	if (!track || (paused && !settings.keepRpcOnPause)) return setRPC();

--- a/plugins/DiscordRPC/src/index.ts
+++ b/plugins/DiscordRPC/src/index.ts
@@ -2,119 +2,131 @@ import { intercept } from "@neptune";
 import { Tracer } from "@inrixia/lib/trace";
 import { settings } from "./Settings";
 import getPlaybackControl from "@inrixia/lib/getPlaybackControl";
-import { MediaItemCache } from "@inrixia/lib/Caches/MediaItemCache";
+import { MediaItem, MediaItemCache } from "@inrixia/lib/Caches/MediaItemCache";
 import type { SetActivity } from "@xhayper/discord-rpc";
 export { Settings } from "./Settings";
 import "./discord.native";
 
 const trace = Tracer("[DiscordRPC]");
 const STR_MAX_LEN = 127;
-const formatLongString = (s?: string) => {
-	if (s === undefined) return undefined;
+const formatString = (s?: string) => {
+	if (!s) return;
 	if (s.length < 2) s += " ";
 	return s.length >= STR_MAX_LEN ? s.slice(0, STR_MAX_LEN - 3) + "..." : s;
 };
-const getMediaURLFromID = (id?: string, path = "/1280x1280.jpg") => (id ? "https://resources.tidal.com/images/" + id.split("-").join("/") + path : undefined);
+const getMediaURL = (id?: string, path = "/1280x1280.jpg") =>
+	id && "https://resources.tidal.com/images/" + id.split("-").join("/") + path;
 
-let previousActivity: string | undefined;
-let previousStartTime = 0;
-let previousEndTime = 0;
+let track: MediaItem | undefined;
+let paused = true;
+let time = 0;
 
-export const onTimeUpdate = async (currentTime?: number) => {
-	const { playbackContext, playbackState } = getPlaybackControl();
-	if (!playbackState) return;
+export function update(data?: {
+	track?: MediaItem;
+	time?: number;
+	paused?: boolean;
+}) {
+	if (data?.track) track = data.track;
+	if (data?.paused !== undefined) paused = data.paused;
+	if (data?.time !== undefined) time = data.time;
 
-	const mediaItem = await MediaItemCache.ensure(playbackContext?.actualProductId!);
-	if (mediaItem === undefined) return;
-
-	const loading = currentTime === 0 && previousActivity;
-	const playing = playbackState !== "NOT_PLAYING" || loading;
-
-	if (!playing && !settings.keepRpcOnPause) {
-		if (!previousActivity) return;
-		setRPC();
-		return (previousActivity = undefined);
-	}
+	// Clear activity if no track or paused
+	if (!track || (paused && !settings.keepRpcOnPause)) return setRPC();
 
 	const activity: SetActivity = { type: 2 }; // Listening type
 
 	if (settings.displayPlayButton)
 		activity.buttons = [
 			{
-				url: `https://tidal.com/browse/${mediaItem.contentType}/${mediaItem.id}?u`,
+				url: `https://tidal.com/browse/${track.contentType}/${track.id}?u`,
 				label: "Play Song",
 			},
 		];
 
 	// Pause indicator
-	if (!playing) {
+	if (paused) {
 		activity.smallImageKey = "paused-icon";
 		activity.smallImageText = "Paused";
 	} else {
 		// Playback/Time
-		if (mediaItem.duration !== undefined && currentTime !== undefined) {
-			const newStartTime = Date.now() - currentTime * 1000;
-			const newEndTime = newStartTime + mediaItem.duration * 1000;
-
-			// Use old timestamps if the difference is less than 100ms, to prevent unnecessary updates
-			if (newEndTime - previousEndTime < 100 && newStartTime - previousStartTime < 100) {
-				activity.startTimestamp = previousStartTime;
-				activity.endTimestamp = previousEndTime;
-			} else {
-				activity.startTimestamp = newStartTime;
-				activity.endTimestamp = newEndTime;
-				previousStartTime = newStartTime;
-				previousEndTime = newEndTime;
-			}
+		if (track.duration !== undefined) {
+			activity.startTimestamp = Date.now() - time * 1000;
+			activity.endTimestamp = activity.startTimestamp + track.duration * 1000;
 		}
 
 		// Artist image
-		const artist = mediaItem.artist ?? mediaItem.artists?.[0];
-		if (artist && settings.displayArtistImage) {
-			activity.smallImageKey = getMediaURLFromID(artist.picture, "/320x320.jpg");
-			activity.smallImageText = formatLongString(artist.name);
+		if (settings.displayArtistImage) {
+			const artist = track.artist ?? track.artists?.[0];
+			activity.smallImageKey = getMediaURL(artist?.picture, "/320x320.jpg");
+			activity.smallImageText = formatString(artist?.name);
 		}
 	}
 
 	// Album
-	if (mediaItem.album !== undefined) {
-		activity.largeImageKey = getMediaURLFromID(mediaItem.album?.cover);
-		activity.largeImageText = formatLongString(mediaItem.album?.title);
+	if (track.album) {
+		activity.largeImageKey = getMediaURL(track.album.cover);
+		activity.largeImageText = formatString(track.album.title);
 	}
 
 	// Title/Artist
-	const artist = mediaItem.artists?.map((a) => a.name).join(", ") ?? "Unknown Artist";
+	activity.details = formatString(track.title);
+	activity.state =
+		formatString(track.artists?.map((a) => a.name).join(", ")) ??
+		"Unknown Artist";
 
-	activity.details = formatLongString(mediaItem.title);
-	activity.state = formatLongString(artist);
-
-	// Check if the activity actually changed
-	const json = JSON.stringify(activity);
-	if (previousActivity === json) return;
-	previousActivity = json;
-
-	return setRPC(activity);
-};
-
-// Debounce RPC updates, to prevent reaching the rate limit
-let lastSetAt = 0;
-let timeoutId: number | undefined;
-function setRPC(activity?: SetActivity) {
-	if (timeoutId) window.clearTimeout(timeoutId);
-	const timeout = Date.now() - lastSetAt < 3000 ? 3000 : 0;
-	timeoutId = window.setTimeout(() => {
-		window.electron.ipcRenderer.invoke("DISCORD_SET_ACTIVITY", activity).catch(trace.err.withContext("Failed to update"));
-		timeoutId = undefined;
-	}, timeout);
-	lastSetAt = Date.now();
+	setRPC(activity);
 }
 
-const onUnloadTimeUpdate = intercept("playbackControls/TIME_UPDATE", ([newTime]) => {
-	onTimeUpdate(newTime).catch(trace.err.withContext("Failed to update"));
+function setRPC(activity?: SetActivity) {
+	window.electron.ipcRenderer
+		.invoke("DISCORD_SET_ACTIVITY", activity)
+		.catch(trace.err.withContext("Failed to set activity"));
+}
+
+const unloadTransition = intercept(
+	"playbackControls/MEDIA_PRODUCT_TRANSITION",
+	([media]) => {
+		const mediaProduct = media.mediaProduct as { productId: string };
+		MediaItemCache.ensure(mediaProduct.productId)
+			.then((track) => {
+				if (track) update({ track, time: 0 });
+			})
+			.catch(trace.err.withContext("Failed to fetch media item"));
+	}
+);
+
+const unloadSeek = intercept("playbackControls/SEEK", ([time]) => {
+	if (typeof time === "number") update({ time });
 });
 
-onTimeUpdate().catch(trace.err.withContext("Failed to update"));
+const unloadPlay = intercept(
+	"playbackControls/SET_PLAYBACK_STATE",
+	([state]) => {
+		if (state === "PLAYING") update({ paused: false });
+	}
+);
+
+const unloadPause = intercept("playbackControls/PAUSE", () => {
+	update({ paused: true });
+});
+
+const { playbackContext, playbackState, latestCurrentTime } =
+	getPlaybackControl();
+
+const newTrack = await MediaItemCache.ensure(playbackContext?.actualProductId);
+
+update({
+	track: newTrack,
+	time: latestCurrentTime,
+	paused: playbackState !== "PLAYING",
+});
+
 export const onUnload = () => {
-	onUnloadTimeUpdate();
-	window.electron.ipcRenderer.invoke("DISCORD_CLEANUP").catch(trace.msg.err.withContext("Failed to cleanup RPC"));
+	unloadTransition();
+	unloadSeek();
+	unloadPlay();
+	unloadPause();
+	window.electron.ipcRenderer
+		.invoke("DISCORD_CLEANUP")
+		.catch(trace.msg.err.withContext("Failed to cleanup RPC"));
 };

--- a/plugins/DiscordRPC/src/index.ts
+++ b/plugins/DiscordRPC/src/index.ts
@@ -74,11 +74,11 @@ export function update(data?: {
 		formatString(track.artists?.map((a) => a.name).join(", ")) ??
 		"Unknown Artist";
 
-	setRPC(activity);
+	return setRPC(activity);
 }
 
 function setRPC(activity?: SetActivity) {
-	window.electron.ipcRenderer
+	return window.electron.ipcRenderer
 		.invoke("DISCORD_SET_ACTIVITY", activity)
 		.catch(trace.err.withContext("Failed to set activity"));
 }

--- a/plugins/DiscordRPC/src/index.ts
+++ b/plugins/DiscordRPC/src/index.ts
@@ -113,10 +113,8 @@ const unloadPause = intercept("playbackControls/PAUSE", () => {
 const { playbackContext, playbackState, latestCurrentTime } =
 	getPlaybackControl();
 
-const newTrack = await MediaItemCache.ensure(playbackContext?.actualProductId);
-
 update({
-	track: newTrack,
+	track: await MediaItemCache.ensure(playbackContext?.actualProductId),
 	time: latestCurrentTime,
 	paused: playbackState !== "PLAYING",
 });


### PR DESCRIPTION
Quite a lot of changes, so I'm making this a pull request so it can be reviewed.

* Listen to specific events instead of just all time updates.
    * It also now updates faster because `MEDIA_PRODUCT_TRANSITION` fires before the song begins playing.
* Removed deduplication/throttling logic because unnecessary events aren't listened to anymore.
* General code cleanup.